### PR TITLE
check-lv-usage.rb script should alert if the volume list is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+
+### Fixed
+- check-lv-usage.rb: emit an `unknown` with a useful message rather than a false `ok` when no volumes are found (@sys-ops)
+
+### Changed
+- general readability improvements and appeasing the cops (@majormoses)
 
 ## [1.0.0] - 2017-07-12
 ### Added

--- a/bin/check-lv-usage.rb
+++ b/bin/check-lv-usage.rb
@@ -83,6 +83,7 @@ class CheckLVUsage < Sensu::Plugin::Check::CLI
   end
 
   def filter_volumes(list)
+    unknown 'An error occured getting the LVM info: got empty list of volumes' if list.empty?
     begin
       return list.select { |l| config[:lv].include?(l.name) } if config[:lv]
       return list.select { |l| config[:full_name].include?(l.full_name) } if config[:full_name]

--- a/bin/check-vg-usage.rb
+++ b/bin/check-vg-usage.rb
@@ -75,7 +75,7 @@ class CheckVg < Sensu::Plugin::Check::CLI
         next if config[:ignorevg] && config[:ignorevg].include?(line.name)
         next if config[:ignorevgre] && config[:ignorevgre].match(line.name)
         next if config[:includevg] && !config[:includevg].include?(line.name)
-      rescue
+      rescue StandardError
         unknown 'An error occured getting the LVM info'
       end
       check_volume_group(line)
@@ -99,9 +99,19 @@ class CheckVg < Sensu::Plugin::Check::CLI
     end
   end
 
-  def to_human(s)
-    unit = [[1_099_511_627_776, 'TiB'], [1_073_741_824, 'GiB'], [1_048_576, 'MiB'], [1024, 'KiB'], [0, 'B']].detect { |u| s >= u[0] }
-    "#{s > 0 ? s / unit[0] : s} #{unit[1]}"
+  def to_human(bytes)
+    units = [
+      [1_099_511_627_776, 'TiB'],
+      [1_073_741_824, 'GiB'],
+      [1_048_576, 'MiB'],
+      [1024, 'KiB'],
+      [0, 'B']
+    ].detect { |unit| bytes >= unit[0] }
+    if bytes > 0
+      bytes / units[0]
+    else
+      units[1]
+    end
   end
 
   # Generate output

--- a/bin/metrics-vg-usage.rb
+++ b/bin/metrics-vg-usage.rb
@@ -1,6 +1,4 @@
 #! /usr/bin/env ruby
-#  encoding: UTF-8
-
 #
 #   metrics-vg-usage
 #
@@ -64,7 +62,7 @@ class VgUsageMetrics < Sensu::Plugin::Metric::CLI::Graphite
         next if config[:ignorevg] && config[:ignorevg].include?(line.name)
         next if config[:ignorevgre] && config[:ignorevgre].match(line.name)
         next if config[:includevg] && !config[:includevg].include?(line.name)
-      rescue
+      rescue StandardError
         unknown 'An error occured getting the LVM info'
       end
       volume_group_metrics(line)


### PR DESCRIPTION
check-lv-usage.rb script should alert if the volume list is empty
this happens when the check is run by a non-root user

## Pull Request Checklist

**Is this in reference to an existing issue?**
no

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
The check should be more verbose. If it gets an empty list of volumes, it should exit instead of showing that everything is correct, when it is not.

#### Known Compatablity Issues
no
