### PR TITLE
Multiple security and misc updates:

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,6 @@ RegexpLiteral:
 Style/Documentation:
   Enabled: false
 AllCops:
+  TargetRubyVersion: 2.3
   Exclude:
     - 'test/**/*.rb'
-    - 'sensu-plugins-lvm.gemspec'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.0
-- 2.1
-- 2.2
 - 2.3.0
 - 2.4.1
 notifications:
@@ -25,9 +22,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
-    rvm: 2.1
-    rvm: 2.2
     rvm: 2.3.0
     rvm: 2.4.1
     repo: sensu-plugins/sensu-plugins-lvm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Breaking Changes
+- removed ruby `< 2.3` support (@majormoses)
+- bumped dependency of `sensu-plugin` to `~> 2.5` you can read about it [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v145---2017-03-07) (@majormoses)
+
+### Security
+- updated yard dependency to `~> 0.9.11` per: https://nvd.nist.gov/vuln/detail/CVE-2017-17042 (@majormoses)
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)
+
+### Changed
+- appeased the cops (@majormoses)
+
+### Removed
+- gemnasium badge (@majormoses)
+
+### Added
+- slack badge (@majormoses)
+
 ## [1.0.1] - 2018-07-06
 ### Fixed
 - check-lv-usage.rb: emit an `unknown` with a useful message rather than a false `ok` when no volumes are found (@sys-ops)

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sensu-plugins-lvm.gemspec

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Gem Version](https://badge.fury.io/rb/sensu-plugins-lvm.svg)](http://badge.fury.io/rb/sensu-plugins-lvm)
 [![Code Climate](https://codeclimate.com/github/sensu-plugins/sensu-plugins-lvm/badges/gpa.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-lvm)
 [![Test Coverage](https://codeclimate.com/github/sensu-plugins/sensu-plugins-lvm/badges/coverage.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-lvm)
-[![Dependency Status](https://gemnasium.com/sensu-plugins/sensu-plugins-lvm.svg)](https://gemnasium.com/sensu-plugins/sensu-plugins-lvm)
+[![Community Slack](https://slack.sensu.io/badge.svg)](https://slack.sensu.io/badge)
 
 ## Functionality
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'github/markup'
 require 'redcarpet'

--- a/bin/check-lv-usage.rb
+++ b/bin/check-lv-usage.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 #   check-lv-usage
 #
@@ -83,13 +85,11 @@ class CheckLVUsage < Sensu::Plugin::Check::CLI
   end
 
   def empty_volumes_msg
-    # NOTE: when we drop ruby < 2.3 support switch to <<~ and indent sanely
-    string = <<-HEREDOC
-    An error occured getting the LVM info: got empty list of volumes.
-    Check to ensure sensu has been configured with appropriate permissions.
-    On linux systems it will generally need to allow executing
+    <<~HEREDOC
+      An error occured getting the LVM info: got empty list of volumes.
+      Check to ensure sensu has been configured with appropriate permissions.
+      On linux systems it will generally need to allow executing `/sbin/lvm`
     HEREDOC
-    string.squeeze(' ')
   end
 
   def filter_volumes(list)

--- a/bin/check-vg-usage.rb
+++ b/bin/check-vg-usage.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 #   check-vg-usage
 #
@@ -72,8 +74,8 @@ class CheckVg < Sensu::Plugin::Check::CLI
   def volume_groups
     LVM::LVM.new.volume_groups.each do |line|
       begin
-        next if config[:ignorevg] && config[:ignorevg].include?(line.name)
-        next if config[:ignorevgre] && config[:ignorevgre].match(line.name)
+        next if config[:ignorevg]&.include?(line.name)
+        next if config[:ignorevgre]&.match(line.name)
         next if config[:includevg] && !config[:includevg].include?(line.name)
       rescue StandardError
         unknown 'An error occured getting the LVM info'
@@ -107,7 +109,7 @@ class CheckVg < Sensu::Plugin::Check::CLI
       [1024, 'KiB'],
       [0, 'B']
     ].detect { |unit| bytes >= unit[0] }
-    if bytes > 0
+    if bytes.positive?
       bytes / units[0]
     else
       units[1]

--- a/bin/metrics-vg-usage.rb
+++ b/bin/metrics-vg-usage.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 #   metrics-vg-usage
 #
@@ -59,8 +61,8 @@ class VgUsageMetrics < Sensu::Plugin::Metric::CLI::Graphite
   def volume_groups
     LVM::LVM.new.volume_groups.each do |line|
       begin
-        next if config[:ignorevg] && config[:ignorevg].include?(line.name)
-        next if config[:ignorevgre] && config[:ignorevgre].match(line.name)
+        next if config[:ignorevg]&.include?(line.name)
+        next if config[:ignorevgre]&.match(line.name)
         next if config[:includevg] && !config[:includevg].include?(line.name)
       rescue StandardError
         unknown 'An error occured getting the LVM info'

--- a/lib/sensu-plugins-lvm.rb
+++ b/lib/sensu-plugins-lvm.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'sensu-plugins-lvm/version'

--- a/lib/sensu-plugins-lvm/version.rb
+++ b/lib/sensu-plugins-lvm/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SensuPluginsLvm
   module Version
     MAJOR = 1

--- a/sensu-plugins-lvm.gemspec
+++ b/sensu-plugins-lvm.gemspec
@@ -1,37 +1,39 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
 require_relative 'lib/sensu-plugins-lvm'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for LVM'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-lvm'
   s.license                = 'MIT'
   s.metadata               = {
-                               'maintainer'         => 'sensu-plugin',
-                               'development_status' => 'active',
-                               'production_status'  => 'unstable - testing recommended',
-                               'release_draft'      => 'false',
-                               'release_prerelease' => 'false'
-                             }
+    'maintainer' => 'sensu-plugin',
+    'development_status' => 'active',
+    'production_status'  => 'unstable - testing recommended',
+    'release_draft'      => 'false',
+    'release_prerelease' => 'false'
+  }
   s.name                   = 'sensu-plugins-lvm'
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.3.0'
   s.summary                = 'Sensu plugins for lvm'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsLvm::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
   s.add_runtime_dependency 'chef-ruby-lvm', '~> 0.3.0'
   s.add_runtime_dependency 'chef-ruby-lvm-attrib', '~> 0.2.1'
+  s.add_runtime_dependency 'sensu-plugin', '~> 2.5'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
@@ -39,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.37'
   s.add_development_dependency 'rspec',                     '~> 3.4'
-  s.add_development_dependency 'yard',                      '~> 0.8'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
+  s.add_development_dependency 'yard',                      '~> 0.9.11'
 end


### PR DESCRIPTION
- removed ruby `< 2.3` support
- updated yard dependency to `~> 0.9.11` [per](https://nvd.nist.gov/vuln/detail/CVE-2017-17042)
- updated rubocop dependency to `~> 0.51.0`[per](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418)
- bumped dependency of `sensu-plugin` to `~> 2.5` you can read about it [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v145---2017-03-07)
- appeased the cops
- removed gemnasium badge
- added slack badge

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist
- https://github.com/sensu-plugins/community/issues/97
- https://github.com/sensu-plugins/community/issues/77


#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

~- [ ] Update README with any necessary configuration snippets~

~- [ ] Binstubs are created if needed~

- [x] RuboCop passes

- [x] Existing tests pass 

#### Testing Artifacts
check-lv-usage.rb:
```
$ bundle exec ./bin/check-lv-usage.rb 
CheckLVUsage UNKNOWN: An error occured getting the LVM info: got empty list of volumes.
Check to ensure sensu has been configured with appropriate permissions.
On linux systems it will generally need to allow executing `/sbin/lvm`

$ sudo /opt/chefdk/embedded/bin/ruby ./bin/check-lv-usage.rb 
[sudo] password for babrams: 
CheckLVUsage OK: All logical volume data usage under 85% and metadata usage under 85%
```

check-vg-usage.rb:
```
$ sudo /opt/chefdk/embedded/bin/ruby ./bin/check-vg-usage.rb 
CheckVg CRITICAL: ubuntu-vg 100.0% bytes usage (475/475)

$ bundle exec ./bin/check-vg-usage.rb 
Check failed to run: Fatal error, ` pvs --verbose --separator=^ --noheadings --nosuffix --units=b --unbuffered --options dev_size,pe_start,pv_allocatable,pv_attr,pv_ba_size,pv_ba_start,pv_duplicate,pv_exported,pv_ext_vsn,pv_fmt,pv_free,pv_in_use,pv_major,pv_mda_count,pv_mda_free,pv_mda_size,pv_mda_used_count,pv_minor,pv_missing,pv_name,pv_pe_alloc_count,pv_pe_count,pv_size,pv_tags,pv_used,pv_uuid,vg_uuid` returned 5 with 'WARNING: Running as a non-root user. Functionality may be unavailable.
  /run/lvm/lvmetad.socket: access failed: Permission denied
  WARNING: Failed to connect to lvmetad. Falling back to device scanning.
  /run/lock/lvm/P_global:aux: open failed: Permission denied
  Unable to obtain global lock.', ["/home/babrams/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/chef-ruby-lvm-0.3.0/lib/lvm/external.rb:19:in `cmd'", "/home/babrams/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/chef-ruby-lvm-0.3.0/lib/lvm/wrapper/pvs.rb:33:in `list'", "/home/babrams/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/chef-ruby-lvm-0.3.0/lib/lvm/physical_volumes.rb:21:in `each'", "/home/babrams/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/chef-ruby-lvm-0.3.0/lib/lvm/physical_volumes.rb:31:in `list'", "/home/babrams/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/chef-ruby-lvm-0.3.0/lib/lvm/volume_groups.rb:26:in `each'", "./bin/check-vg-usage.rb:75:in `volume_groups'", "./bin/check-vg-usage.rb:128:in `run'", "/home/babrams/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sensu-plugin-2.5.0/lib/sensu-plugin/cli.rb:57:in `block in <class:CLI>'"]

```

metrics-vg-usage.rb:
```
$ bundle exec ./bin/metrics-vg-usage.rb 
Check failed to run: Fatal error, ` pvs --verbose --separator=^ --noheadings --nosuffix --units=b --unbuffered --options dev_size,pe_start,pv_allocatable,pv_attr,pv_ba_size,pv_ba_start,pv_duplicate,pv_exported,pv_ext_vsn,pv_fmt,pv_free,pv_in_use,pv_major,pv_mda_count,pv_mda_free,pv_mda_size,pv_mda_used_count,pv_minor,pv_missing,pv_name,pv_pe_alloc_count,pv_pe_count,pv_size,pv_tags,pv_used,pv_uuid,vg_uuid` returned 5 with 'WARNING: Running as a non-root user. Functionality may be unavailable.
  /run/lvm/lvmetad.socket: access failed: Permission denied
  WARNING: Failed to connect to lvmetad. Falling back to device scanning.
  /run/lock/lvm/P_global:aux: open failed: Permission denied
  Unable to obtain global lock.', ["/home/babrams/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/chef-ruby-lvm-0.3.0/lib/lvm/external.rb:19:in `cmd'", "/home/babrams/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/chef-ruby-lvm-0.3.0/lib/lvm/wrapper/pvs.rb:33:in `list'", "/home/babrams/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/chef-ruby-lvm-0.3.0/lib/lvm/physical_volumes.rb:21:in `each'", "/home/babrams/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/chef-ruby-lvm-0.3.0/lib/lvm/physical_volumes.rb:31:in `list'", "/home/babrams/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/chef-ruby-lvm-0.3.0/lib/lvm/volume_groups.rb:26:in `each'", "./bin/metrics-vg-usage.rb:62:in `volume_groups'", "./bin/metrics-vg-usage.rb:86:in `run'", "/home/babrams/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sensu-plugin-2.5.0/lib/sensu-plugin/cli.rb:57:in `block in <class:CLI>'"]

$ sudo /opt/chefdk/embedded/bin/ruby ./bin/metrics-vg-usage.rb 
babrams-ThinkPad-X1-Carbon-5th.vg_usage.ubuntu-vg.used 511054970880 1530863560
babrams-ThinkPad-X1-Carbon-5th.vg_usage.ubuntu-vg.avail 0 1530863560
babrams-ThinkPad-X1-Carbon-5th.vg_usage.ubuntu-vg.used_percentage 100.0 1530863560
```

#### Purpose
Address multiple CVE's, misc clearnup

#### Known Compatablity Issues
- Removes Ruby `< 2.3` support
- disables in event filtering (not really relevant since there are no handlers)
