### PR TITLE
bumped chef-ruby-lvm-attrb version to meet requirements for new lvm2-…

### DIFF
--- a/sensu-plugins-lvm.gemspec
+++ b/sensu-plugins-lvm.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.version                = SensuPluginsLvm::Version::VER_STRING
 
   s.add_runtime_dependency 'chef-ruby-lvm', '~> 0.3.0'
-  s.add_runtime_dependency 'chef-ruby-lvm-attrib', '~> 0.2.1'
+  s.add_runtime_dependency 'chef-ruby-lvm-attrib', '~> 0.3.0'
   s.add_runtime_dependency 'sensu-plugin', '~> 2.5'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'


### PR DESCRIPTION
…2.02.186 rpm package

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues

####################################
####################################

This version bump is required for sensu lvm check where it tries to search for lvs.yaml file in (lvm2-2.02.186) directory, since the version of lvm attributes is old, sensu-plugins-lvm-2.0.0 cannot pick up the newest available. All "chef-ruby-lvm-attrib" versions below 0.3.0 do not have this directory and sensu fails.